### PR TITLE
Fix hardcoded links and fix width blocks

### DIFF
--- a/docs/faq/general-faq.md
+++ b/docs/faq/general-faq.md
@@ -51,4 +51,4 @@ You can’t easily share volumes in OpenStack without deploying a Shared File Sy
 
 Instructions for using manila on Jetstream2 are here: 
   
-[Manila - Filesystems-as-a-service - on Jetstream2](https://docs.jetstream-cloud.org/general/manila/#manila-filesystems-as-a-service-on-jetstream2)
+[Manila - Filesystems-as-a-service - on Jetstream2](../general/manila.md)

--- a/docs/general/kubernetes.md
+++ b/docs/general/kubernetes.md
@@ -24,7 +24,7 @@ Some K8s basics :
 
 ### Other Kubernetes topics
 
-[Building a Kubernetes Cluster](https://docs.jetstream-cloud.org/general/k8scluster/)  
-[Managing applications with Kubernetes](https://docs.jetstream-cloud.org/general/k8smanage/)  
-[Persistent Volumes in Kubernetes](https://docs.jetstream-cloud.org/general/k8svolumes/)  
-[Minikube](https://docs.jetstream-cloud.org/general/minikube/)  
+[Building a Kubernetes Cluster](./k8scluster.md)  
+[Managing applications with Kubernetes](./k8smanage.md)  
+[Persistent Volumes in Kubernetes](./k8svolumes.md)  
+[Minikube](./minikube.md)  

--- a/docs/general/manila.md
+++ b/docs/general/manila.md
@@ -6,6 +6,6 @@ Prereqs: Make sure you have these packages installed on your instance: ceph-comm
 
 Follow the links below to use: 
 
-    - [Manila via Horizon](https://docs.jetstream-cloud.org/general/manilaHorizon/)  
-    - [Manila via Openstack CLI](https://docs.jetstream-cloud.org/general/manilaOpenstack/)
+ - [Manila via Horizon](./manilaHorizon.md)  
+ - [Manila via Openstack CLI](./manilaOpenstack.md)
 

--- a/docs/general/manilaHorizon.md
+++ b/docs/general/manilaHorizon.md
@@ -9,10 +9,10 @@ i. Click on:  Project  → Share → Shares → Create Share <br>
   
 ii. Create a share with the following settings:
 
-    - share name - a name of your choosing  
-    - share protocol - CephFS    
-    - size - the size of your manila share  
-    - share type - cephnfsnativetype  
+- share name - a name of your choosing  
+- share protocol - CephFS    
+- size - the size of your manila share  
+- share type - cephnfsnativetype  
   
 ![image](../images/JS2-manila2.png)  
 &nbsp;  
@@ -23,9 +23,9 @@ i. Once your share is available you can select `Edit Share` and `Manage Rules` a
    
 ![image](../images/JS2-manila3.png)  &nbsp;
 
-    - access type - cephx  
-    - access level - read-write  
-    - access to - an arbitrary unique name   
+- access type - cephx  
+- access level - read-write  
+- access to - an arbitrary unique name   
 
 
 In the example above the accessTo name is `manilashare`. The name assigned must be globally unique, if you use a name that is already in use you will see and error state.   
@@ -35,10 +35,10 @@ In the example above the accessTo name is `manilashare`. The name assigned must 
 
 ii.  If you now go back to the share page (Project/Share/Shares) and click on the share you created you should see your share's metadata.  
     
-    Important things to note here are :
+Important things to note here are :
 
-    - Path - ips:ports followed by volume path (/volume/\_no-group/...)
-    - Access Key 
+- Path - ips:ports followed by volume path (/volume/\_no-group/...)
+- Access Key 
   
     
  
@@ -47,6 +47,6 @@ ii.  If you now go back to the share page (Project/Share/Shares) and click on th
 
 ### Using Manila Share on a VM
 
-a. [Centos/Rocky](https://docs.jetstream-cloud.org/general/manilaVM/#3-a-configuring-a-centosrocky-instance)    
-b. [Ubuntu](https://docs.jetstream-cloud.org/general/manilaVM/#3-b-configuring-a-ubuntu-instance)  
+a. [Centos/Rocky](./manilaVM.md#2-a-configuring-a-centosrocky-instance)    
+b. [Ubuntu](./manilaVM.md#2-b-configuring-a-ubuntu-instance)  
 

--- a/docs/general/manilaOpenstack.md
+++ b/docs/general/manilaOpenstack.md
@@ -157,15 +157,15 @@ In the above example it is:
 
 --- 
 
-    Important things to note down: 
+Important things to note down: 
 
-    - Share id (Step 1)
-    - Access rule id (Step 2)
-    - Acccess key (Step 3)
-    - Export location path (Step 4)
+- Share id (Step 1)
+- Access rule id (Step 2)
+- Acccess key (Step 3)
+- Export location path (Step 4)
 
 
 ### Using Manila Share on a VM
 
-a. [Centos/Rocky](https://docs.jetstream-cloud.org/general/manilaVM/#3-a-configuring-a-centosrocky-instance)  
-b. [Ubuntu](https://docs.jetstream-cloud.org/general/manilaVM/#3-b-configuring-a-ubuntu-instance)  
+a. [Centos/Rocky](./manilaVM.md#2-a-configuring-a-centosrocky-instance)    
+b. [Ubuntu](./manilaVM.md#2-b-configuring-a-ubuntu-instance)  


### PR DESCRIPTION
Fixed 

- Hard-coded links (e.g. changed `https://docs.jetstream-cloud.org/general/k8scluster/` to `./k8scluster.md`)
- Indented blocks which turned into fixed-width text
- Incorrect relative links (e.g. changed `./manilaVM.md#3-a-configuring-a-centosrocky-instance` to `./manilaVM.md#2-a-configuring-a-centosrocky-instance`)

## Indented blocks breaking manila links by turning into fixed-width

### Before

![js2-manila-links-before](https://user-images.githubusercontent.com/742633/157736386-0661b474-0c10-4955-ad1f-ae31d9fbc3d4.png)

### After

![js2-manila-links-after](https://user-images.githubusercontent.com/742633/157736397-4bbbd5d6-5ba9-4115-bc3e-0e092731f2a9.png)

## Indented block (example)

### Before

![js2-list-before](https://user-images.githubusercontent.com/742633/157737181-6272a6bf-a1d6-4126-8798-59b38ded4ad5.png)

### After

![js2-list-after](https://user-images.githubusercontent.com/742633/157737190-4abf838b-ce7e-498a-89ec-63cc63218dcd.png)

