### PR TITLE
Various Fixes and Additions

### DIFF
--- a/docs/faq/alloc.md
+++ b/docs/faq/alloc.md
@@ -19,7 +19,7 @@
 
 > The [Research Allocation](../alloc/research.md) page has information and links for writing a successful Jetstream2 research allocation request.
 >
-> There is a Cornell Virtual Workshop (CVW) on getting a Research Allocation for Jetstream here: https://cvw.cac.cornell.edu/JetstreamReq/. It is not updated for Jetstream2 though the principles are the same.
+> There is a Cornell Virtual Workshop (CVW) on getting a Research Allocation for Jetstream here: [https://cvw.cac.cornell.edu/JetstreamReq/](https://cvw.cac.cornell.edu/JetstreamReq/). It is not updated for Jetstream2 though the principles are the same.
 
 ---
 

--- a/docs/faq/general-faq.md
+++ b/docs/faq/general-faq.md
@@ -132,7 +132,7 @@ Tutorials like [How to Run Linux Commands in Background](https://linuxize.com/po
 
 show a number of methods shown here on how to start a program and leave it running, even if your connection disconnects.
 
-I'd suggest looking at the nohup command. As that page says:
+We would suggest looking at the nohup command. As that page says:
 
 *"Another way to keep a process running after the shell exit is to use nohup.*
 

--- a/docs/faq/general-faq.md
+++ b/docs/faq/general-faq.md
@@ -114,7 +114,7 @@ Additionally, there are NSF-funded resources like the Open Storage Network (OSN)
 
 ### What are the IP ranges / CIDR blocks for Jetstream2 ?
 
-The current CIDR blocks for Jetstrea2 are:
+The current CIDR blocks for Jetstream2 are:
 
 ```
 149.165.152.0/22

--- a/docs/general/docker.md
+++ b/docs/general/docker.md
@@ -1,6 +1,6 @@
 # Containers on Jetstream2
 
-Containers are isolated environments in which to run your applications. They created by objects called images. An image is defined as a read only template with instructions for creating a container. These instructions define everything a container needs; Software, dependencies, system libraries, environment variables, configuration files, etc.
+Containers are isolated environments in which to run your applications. They are created by objects called images. An image is defined as a read only template with instructions for creating a container. These instructions define everything a container needs; Software, dependencies, system libraries, environment variables, configuration files, etc.
 
 Jetstream2 supports Docker and Apptainer/Singularity. Other container software may be included in the future.
 

--- a/docs/general/galaxy.md
+++ b/docs/general/galaxy.md
@@ -4,7 +4,7 @@
 genomic data analysis, although support other domains is growing:
 machine learning, natural language processing, climate science. **Galaxy enables
 scientists to share, analyze and visualize their own data via a browser.**
-Thounsands of modern and popoular tools are readily available alongside
+Thousands of modern and popoular tools are readily available alongside
 pre-formatted reference data. There are also [extensive training
 resources](https://training.galaxyproject.org/){target=_blank} for a variety of roles,
 including researchers, tool developers, and educators.

--- a/docs/general/policies.md
+++ b/docs/general/policies.md
@@ -50,7 +50,7 @@ restrictions.
 * Only g3.* flavors should be run on the Jetstream2-GPU resource
 * Only r3.* flavors should be run on the Jetstream2-LargeMemory resource
 * Running standard compute (m3.*) flavors on the specialty resources may result in those instances being deleted without warning
-* At some future point, if GPU or large memory resources are scarce, we may limit runtime to two week spans or institute some form VM scheduling service to ensure equitable access to all. We do not anticipate doing this at this time.
+* At some future point, if GPU or large memory resources are scarce, we may limit runtime to two week spans or institute some form of VM scheduling service to ensure equitable access to all. We do not anticipate doing this at this time.
 
 ### Allocation Related Policies
 

--- a/docs/overview/overview-doc.md
+++ b/docs/overview/overview-doc.md
@@ -14,13 +14,13 @@ Jetstream features multiple user interfaces, including the following _**web-base
 - [Horizon](../ui/horizon/intro.md)
 - [Cacao](../ui/cacao/intro.md)
 
-as well as [the OpenStack Command Line Interface (CLI)](../ui/cli/overview.md) and the [OpenStack Software Development Kit (SDK)](https://docs.openstack.org/openstacksdk/latest/){target=_blank})
+as well as [the OpenStack Command Line Interface (CLI)](../ui/cli/overview.md) and the [OpenStack Software Development Kit (SDK)](https://docs.openstack.org/openstacksdk/latest/){target=_blank}.
 
 The operational software environment is based on [OpenStack](https://www.openstack.org/){target=_blank}.
 
 ### Accessing Jetstream ###
 
-Jetstream2 is primarily accessible through either the [Exosphere](../ui/exo/exo.md) web interface using [ACCESS](https://access-ci.org/){target=_blank} credentials via [CILogon](https://www.cilogon.org/faq/){target=_blank}.
+Jetstream2 is primarily accessible through the [Exosphere](../ui/exo/exo.md) web interface using [ACCESS](https://access-ci.org/){target=_blank} credentials via [CILogon](https://www.cilogon.org/faq/){target=_blank}.
 
 
 >Newly created ACCESS accounts must be [added to a Jetstream2 specific allocation](https://allocations.access-ci.org/user_management){target=_blank} by the PI or Resource manager in order to access Jetstream2.

--- a/docs/ui/cli/managing-ssh-keys.md
+++ b/docs/ui/cli/managing-ssh-keys.md
@@ -38,6 +38,8 @@ Then you can create your key
 
 The first will create a 2048 bit RSA cryptography key with the comment you specify and the filename id_rsa (which is the default). The second will create an Ed25519 elliptical cryptography key. The comment is optional but we do recommend it to keep track of keys. *You only need to do one of these, though you can create both.*
 
+***Note***: It is always good practice to secure your ssh keys with a password! Some platforms (for example, Ubuntu 20.04 LTS) will also refuse ssh connections using unprotected keys by default.
+
 You may also leave off the -f file option and ssh-keygen will prompt you for the filename.
 
     openstack keypair create --public-key id_rsa.pub my-api-key

--- a/docs/ui/cli/troubleshooting.md
+++ b/docs/ui/cli/troubleshooting.md
@@ -24,6 +24,17 @@ If your application credential secret in the openrc contains some punctuation/sp
 
 For example, if you had an ampersand in your credential password, it may have gotten escaped to **\&amp\;** instead of just the ampersand character. The same could happen for less than or greater than signs and potentially other special characters. Double check the openrc to verify that that has not happened.
 
+#### I get an error when trying to `source` my openrc file
+
+If your **secret** (password/passphrase) contains spaces, the openrc.sh file that Horizon generates may not have the field properly enclosed in quotes, resulting in an error message similar to `export: 'example!' not a valid identifier`.
+
+Simply open the file in the text editor of your choice and edit the line `export OS_APPLICATION_CREDENTIAL_SECRET`. For example: 
+
+1. `vi openrc.sh`
+2. Press `i` to enter insertion mode
+3. Change `export OS_APPLICATION_CREDENTIAL_SECRET=secret example!` to `export OS_APPLICATION_CREDENTIAL_SECRET="secret example!"`
+4. Press `esc` and type `:wq`, then hit `enter` to save your changes.
+
 ### View the console log
 
 Sometimes you may need to look at the console log for troubleshooting purposes or even just to see if the boot completed normally. You can do this with

--- a/docs/ui/exo/exo.md
+++ b/docs/ui/exo/exo.md
@@ -24,9 +24,9 @@ The other OpenStack interfaces support more features of OpenStack that Exosphere
 
 Instances created via these other tools do _not_ get a one-click shell, desktop, data upload/download tool, or any of the other interactions that Exosphere sets up for you. If you want these with the other OpenStack interfaces, you must set them up yourself with varying degrees of difficulty.
 
-### How Exosphere compares with Atmosphere2
+### How Exosphere compares with Cacao (Atmosphere2)
 
-This section will be populated once Atmosphere2 is ready enough to explore and compare.
+This section will be populated once [Cacao (Atmosphere2)](../cacao/overview.md) is ready enough to explore and compare.
 
 ## Getting Help
 

--- a/docs/ui/horizon/manila.md
+++ b/docs/ui/horizon/manila.md
@@ -37,7 +37,7 @@ i. Once your share is available you can select `Edit Share` and `Manage Rules` a
 
 ![](/images/JS2-manila4.png){ align=right ; width=50% }
 
-In the example above the `accessTo` name is `manilashare`.</br>***The name assigned must be globally unique, if you use a name that is already in use you will see an error state.***
+In the example above the `accessTo` name is `manilashare`.</br>***The name assigned must be globally unique!*** If you use a name that is already in use you will see an error state. To help avoid accidental overlap, we recommend prefixing your name with something unique such as your ACCESS username or your allocation number. For example, instead of using just `seed-research`, use `<ALLOCATION>-seed-research`.
 
 </br></br></br></br></br></br></br></br>
 


### PR DESCRIPTION
- https://docs.jetstream-cloud.org/overview/overview-doc/ 
	- Fixed awkward wording (removed "either")
	- Removed an unnecessary trailing paren. 
- https://docs.jetstream-cloud.org/general/policies/ 
	- Fixed awkward wording (added an "of")
- https://docs.jetstream-cloud.org/faq/general-faq/ 
	- Changed “I’d suggest…” to “We would suggest…” for more profession/inclusive wording
- https://docs.jetstream-cloud.org/faq/alloc/ 
	- fixed broken link https://cvw.cac.cornell.edu/JetstreamReq/ 
- https://docs.jetstream-cloud.org/ui/exo/exo/ 
	- Updated references to "Atmosphere2" to "Cacao (Atmosphere2)"
	- Added a link to the overview page for Cacao
- https://docs.jetstream-cloud.org/faq/general-faq/ 
	- “CIDR blocks for Jetstrea2” to "CIDR blocks for Jetstream2"
- https://docs.jetstream-cloud.org/ui/cli/troubleshooting/
	- If you use spaces in your secret (*which our docs actually suggest to do*), you will be unable to `source` the resulting openrc file, since it does not enclose the secret in quotation marks. This is an easy fix (Open the file -> add quotes around your secret), but otherwise you’ll get “export: `example!` not a valid identifier” 
- https://docs.jetstream-cloud.org/ui/cli/managing-ssh-keys/ 
	- Added a note encouraging users to secure their ssh keys with passwords
- https://docs.jetstream-cloud.org/ui/horizon/manila/ 
	- Added more detail to the note about share names needing to be unique, suggesting to prefix  the name with something unique like a username or allocation number.
- https://docs.jetstream-cloud.org/general/galaxy/ 
	- “Thounsands”
- https://docs.jetstream-cloud.org/general/docker/ 
	- “They [^are] created”