### PR TITLE
Update GPU FAQ entry for CUDA versions

### DIFF
--- a/docs/faq/gpu.md
+++ b/docs/faq/gpu.md
@@ -61,4 +61,10 @@ For other GPU software, where possible, we highly recommend using containers fro
 
 ### What CUDA version do I need for Jetstream2 GPUs ?
 
-While NVIDIA says CUDA versions are backward compatible, we recommend using at least the same major revision
+We recommend using the same major revision as reported by `nvidia-smi`; however, NVIDIA maintains that CUDA versions are backward compatible, up to one major revision ago. For example, if `nvidia-smi` reports:
+```
++-----------------------------------------------------------------------------+
+| NVIDIA-SMI 525.60.13    Driver Version: 525.60.13    CUDA Version: 12.0     |
+|-------------------------------+----------------------+----------------------+
+```
+then it is "safe" to use CUDA 11.x, though CUDA 12.0 is recommended. In this example, CUDA 10.x and older will not work.


### PR DESCRIPTION
The existing FAQ item didn't make it clear how compatibility is actually determined. The advice to use the same major version is useful, though impractical for most at the time of writing, since CUDA 12.0 is pretty new and has yet to be adopted widely.