### PR TITLE
Warning to restrict IPs for RDP

### DIFF
--- a/docs/general/windows.md
+++ b/docs/general/windows.md
@@ -63,6 +63,9 @@ Under normal circumstances, RDP listens for connections on TCP port 3389 and may
 
 You can add this rule to an existing [security group](../../ui/horizon/security_group) or create a new one, then apply the security group to your instance by navigating to "Edit Security Groups" in the [management actions dropdown](../../ui/horizon/manage/#instance-management-actions).
 
+!!! warning "Minimize security risks."
+    We **strongly** advise limiting remote access to RDP port(s) to the smallest possible CIDR or, even better, single IP(s), rather than the default `0.0.0.0/0` (which allows access from any public IP); an improperly configured RDP service could allow remote access to a host in an unintended manner in addition to exposing SSL/TLS certificate information. 
+
 <img alt="A screenshot of the RDP security rule in a dropdown menu" src="/images/horizon-rdp-group.png" width="65%"/>
 
 ### Enabling Remote Desktop


### PR DESCRIPTION
Leaving RDP ports open is a notorious security risk, especially if they're on the default 3389. Without an explicit mention to limit remote access, our docs may encourage users to add a security rule with a `0.0.0.0` CIDR. At the worst this could mean compromised VMs, or at the very least an annoying email from IU's information security office.