### PR TITLE
Link to tutorial on Updating Openstack credentials in Kubernetes

### DIFF
--- a/docs/general/kubernetes.md
+++ b/docs/general/kubernetes.md
@@ -20,6 +20,7 @@ More information on Kubernetes here: [Kubernetes](https://kubernetes.io/docs/con
 - [Deploy Kubernetes with kubespray](https://t.co/Hh8ZincbdN){target=_blank}
     - [Feedback via Github](https://t.co/3EXyrp0EEd){target=_blank}
 - [Deploy ProjectJupyter JupyterHub](https://www.zonca.dev/posts/2022-03-31-jetstream2_jupyterhub){target=_blank}
+- [Update Openstack credentials in Kubernetes](https://www.zonca.dev/posts/2023-03-23-update-openstack-credentials-kubernetes){target=_blank}, useful if the Application Credential generated for Kubernetes has expired.
 
 ---
 Some K8s basics :


### PR DESCRIPTION
This is a minor topic, it is not worth having a dedicated page on the JS2 docs website. However, Jetstream 2 users could be affected, so useful to link it here.