### PR TITLE
Add canary status badge

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ For a more in-depth description please see the [System Overview](/overview/overv
   </tbody>
 </table>
 
+[![canary pipeline status](https://gitlab.com/jetstream-cloud/canary/badges/main/pipeline.svg?key_text=canary+pipeline&key_width=100)](https://gitlab.com/jetstream-cloud/canary/-/pipelines) 
+
 Please visit <a href="https://jetstream.status.io/" target=_blank>https://jetstream.status.io/</a> for detailed system status information and planned maintenance announcements. Also see, [Jetstream2 system status and information](overview/status.md) for additional information on our [outages and maintenance mailing list](overview/status.md#mailing-list-for-outages-and-maintenance) and [community chat](overview/status.md#community-chat).
 
 ---

--- a/docs/overview/status.md
+++ b/docs/overview/status.md
@@ -21,9 +21,7 @@
   </tbody>
 </table>
 
-Jetstream2 is maintaining a system status and announcement site at <a href="https://jetstream.status.io/" target=_blank>https://jetstream.status.io/</a>
-
-Please visit that site for detailed system status information and planned maintenance announcements.
+Jetstream2 maintains a system status and announcement site at [https://jetstream.status.io](https://jetstream.status.io). Please visit that site for detailed system status information and planned maintenance announcements.
 
 ##### Mailing list for outages and maintenance
 

--- a/docs/overview/status.md
+++ b/docs/overview/status.md
@@ -23,6 +23,12 @@
 
 Jetstream2 maintains a system status and announcement site at [https://jetstream.status.io](https://jetstream.status.io). Please visit that site for detailed system status information and planned maintenance announcements.
 
+### Canary
+
+[![canary pipeline status](https://gitlab.com/jetstream-cloud/canary/badges/main/pipeline.svg?key_text=canary+pipeline&key_width=100)](https://gitlab.com/jetstream-cloud/canary/-/pipelines) 
+
+The canary is a continuous integration pipeline that tests Jetstream2's primary (IU) region every few hours. If the status site is Operational but the badge above indicates a failing pipeline, this suggests a new systemic issue that needs staff attention.
+
 ##### Mailing list for outages and maintenance
 
 We also have a mailing list that receives system notices. All JS2 researchers, educators, and students get automatically added when they receive JS2 access. You may also subscribe by emailing *js2-users-l-subscribe AT list.iu.edu* or by contacting JS2 help to be added.


### PR DESCRIPTION
This adds a status badge for the canary pipeline to the docs site with a bit of information about what it means. (See https://gitlab.com/jetstream-cloud/project-mgt/-/issues/59 for background.)

![image](https://github.com/jetstream-cloud/js2docs/assets/13605043/f1ca74ec-a36f-434b-9c04-ad31209abf0f)
