### PR TITLE
cacao cli updates

### DIFF
--- a/docs/ui/cacao/cacao_cli_deploy_resources.md
+++ b/docs/ui/cacao/cacao_cli_deploy_resources.md
@@ -1,0 +1,174 @@
+![cacao logo](images/cacao-logo.png){ width=128px }[CACAO Overview](overview.md) &gg; CACAO CLI Deploying Cloud Resources
+
+# CACAO CLI: Deploying Cloud Resources Introduction
+
+If you are a command-line user, you can use the CACAO CLI to deploy cloud resources, defined by an imported template within CACAO. The CACAO CLI is a Go program that can be installed on any system. Before you can use the CACAO CLI to deploy cloud resources, you must first install the CACAO CLI and login using an API token. See [CACAO CLI Login](cacao_cli_login.md) for more information.
+
+Most users will want to use the CACAO user interface to deploy cloud resources; however, there may be use cases where you want to deploy cloud resources from the command line to automate CACAO from scripts or the flexibility of using files to configure resources. This tutorial is for you.
+
+The process to deploy cloud resources with the CACAO CLI is described as follows:
+
+1. Deployment: Collect the required input information
+
+- Workspace ID
+- Provider ID
+- Credential ID
+- Template ID
+
+2. Deployment: Use the CACAO CLI to create a deployment object
+4. Deployment Run: Use the CLI to create a deployment run object with the JSON file
+
+Here are some additional notes about the process:
+
+* A Deployment is a meta-object that describes a cloud resources and the metadata separate from the tasks that create, update, or delete cloud resources. A Deployment Run is a specific creation or modification of a Deployment object, which includes state information (like power state) and parameter information for the template. This separation will allow advanced users to interact with cloud resources like a workflow more easily and in the future have these cloud resources respond to external sources, such as triggering an execution when data changes rather than one-time deployments.
+* Any state changes, such as changing the `power_state` from `active` to `shutoff`, requires a new Deployment Run object to be created. This can easily be done by modifying the JSON file and re-running the `cacao deployment-run create` command.
+* The output of the cacao cli is a JSON-formatted response. For convenience, you can use the `jq` cli command to "prettify" the JSON output. For example, `cacao workspace get | jq` will return a human-readable version of json from the list of workspaces or `cacao workspace get | jq '.[0].id` will return the workspace id from the first element in the workspace list.
+* You can use the CLI to also create cloud and ssh credentials but it will be easier create credentials using the CACAO user interface before attempting a deployment. See [Credentials tutorial](credentials.md) for more information.
+
+## Deployment: Collect the required input information
+
+1. Obtain the workspace `id` for "Default Workspace" (there should only be one workspace): `cacao workspace get`
+2. Obtain the provider `id` for "Jetstream 2". If you have more than one provider, be sure to select the Jetstream2 provider id: `cacao provider get`
+3. Obtain the Jetstream2 credential `id` for your ACCESS allocation. See ***Note 4*** above: `cacao credential get`
+4. Obtain the template `id` for the template you wish to deploy. See [Templates tutorial](templates.md) for more information: `cacao template get`
+
+## Deployment: Use the CACAO CLI to create a deployment object
+
+You can now use the CACAO CLI to create a Deployment object. A Deployment is needed to create a Deployment Run object, which ultimately creates cloud resources. Using the information you obtained from the previous section, you can construct the cacao cli command to create a Deployment object. The format will be similar to:
+
+```bash
+cacao deployment create <workspaceID> <templateID> <providerID> --cloud-creds <credentialID> --name <the name of my deployment>
+```
+
+Below is an example cacao cli along with example output, a json-formatted response. Your ids will likely be different. 
+
+```bash
+cacao deployment create workspace-cb84e8j761e3iagh6123 template-cb75nk6he38e5pi5k456 provider-cb6q6ruhe388cqs04098 --cloud-creds cred-cdgrubj761efbe3v7734 --name esprod-cacaocli-0130
+{
+    "tid": "deployment-cm1mnlhetpqfb6q4u23g",
+    "timestamp": "2024-01-30T21:36:22.422622628Z"
+}
+```
+
+The Deployment id, indicated by the `tid` field from the output, is needed to create the a Deployment Run. Copy this id.
+
+# Deployment Run: Use the CLI to create a deployment run object with the JSON file
+
+To create a Deployment Run, you can use example JSON file below. Simply copy and paste into a new file using your favorite editor. In this example, this file is named  `deployment_run.json`, but you can name it whatever you desire; This example JSON file only works for the openstack-single-image template and other templates will likely require different parameters. To view a template's parameter list, use the following command, `cacao template get <template-id>`, to view the accepted `parameters`. 
+
+You will need to modify the values with the information that you collected from the previous sections and set the template parameters according to the template you are using.
+
+***NOTE 1:*** The `deployment_id` is the same deployment id outputted in the previous section
+
+***NOTE 2:*** The `cloud_credentials` must be the same cloud credentials used to create the deployment object.
+
+***NOTE 3:*** Some template parameters will likely reference openstack specific values, such as a `flavor` and `image_name`. You can use the CLI `cacao provider` operation to get this information. It is also just as easy to use the openstack cli or Horizon ([https://js2.jetstream-cloud.org](https://js2.jetstream-cloud.org)) to get this information.
+
+
+```json
+{
+    "deployment_id": "deployment-cm1mnlhetpqfb6q4u23g",
+    "cloud_credentials": ["cred-cdgrubj761efbe3v7734"],
+    "git_credential_id": "",
+    "parameters": [
+        {
+            "key": "flavor",
+            "value": "m3.tiny"
+        },
+        {
+            "key": "project",
+            "value": "MY-ACCESS-PROJECT"
+        },        
+        {
+            "key": "image_name",
+            "value": "Featured-Ubuntu22"
+        },
+        {
+            "key": "instance_count",
+            "value": "1"
+        },
+        {
+            "key": "instance_name",
+            "value": "my-cacao-instance"
+        },
+        {
+            "key": "power_state",
+            "value": "active"
+        }
+    ]
+}
+```
+
+After the JSON file has been created, you can create a Deployment Runy with a simple command:
+
+```bash
+cacao run create -f run.json
+{
+    "tid": "run-cmsov31etpqfb6q4ugu0",
+    "timestamp": "2024-01-31T00:08:44.763310345Z"
+}
+```
+
+# Deployment Run: Use the CLI to "update" or change the state a deployment object with the JSON file
+
+To update the Deployment, you need to create a new Deployment Run to reflect the changed state.
+
+For example, to update the `power_state`, you can simply change the value in the JSON file and re-run the `cacao run create -f run.json` command. 
+
+***Note 1:*** For instance type deployments, the `power_state` parameter can be set to the following
+
+* `active`
+* `shutoff`
+* `suspendd`
+* `shelved_offloaded`
+
+***Note 2:*** When you change the state of a Deployment Run, you may need to refresh the browser in the UI to see the updated state.
+
+Here is the updated JSON file with the `power_state` set to `shutoff`:
+
+```json
+{
+    "deployment_id": "deployment-cm1mnlhetpqfb6q4u23g",
+    "cloud_credentials": ["cred-cdgrubj761efbe3v7734"],
+    "git_credential_id": "",
+    "parameters": [
+        {
+            "key": "flavor",
+            "value": "m3.tiny"
+        },
+        {
+            "key": "project",
+            "value": "MY-ACCESS-PROJECT"
+        },        
+        {
+            "key": "image_name",
+            "value": "Featured-Ubuntu22"
+        },
+        {
+            "key": "instance_count",
+            "value": "1"
+        },
+        {
+            "key": "instance_name",
+            "value": "my-cacao-instance"
+        },
+        {
+            "key": "power_state",
+            "value": "shutoff"
+        }
+    ]
+}
+```
+
+# Deployment Run: Use the CLI to "delete" the Deployment
+
+To delete a Deployment, you can simply use the `cacao deployment delete` command, such as:
+
+```bash
+cacao deployment delete deployment-cmsmnlhetpqfb6q4ufpg
+{
+    "id": "deployment-cmsmnlhetpqfb6z4ufpg",
+    "tid": "deployment-cmsmnlhetpqfb6q4ufp0",
+    "timestamp": "2024-01-31T00:20:57.773777446Z"
+}
+```

--- a/docs/ui/cacao/cacao_cli_import_terraform_template.md
+++ b/docs/ui/cacao/cacao_cli_import_terraform_template.md
@@ -1,4 +1,4 @@
-![cacao logo](images/cacao-logo.png){ width=128px }[CACAO Overview](overview.md) &gg; Importing a Terraform Template
+![cacao logo](images/cacao-logo.png){ width=128px }[CACAO Overview](overview.md) &gg; CACAO CLI Importing a Terraform Template
 
 # Why create my own Terraform templates?
 

--- a/docs/ui/cacao/cacao_cli_login.md
+++ b/docs/ui/cacao/cacao_cli_login.md
@@ -1,18 +1,18 @@
-![cacao logo](images/cacao-logo.png){ width=128px }[CACAO Overview](overview.md) &gg; Using the CACAO CLI
+![cacao logo](images/cacao-logo.png){ width=128px }[CACAO Overview](overview.md) &gg; CACAO CLI Installing and Logging In
 
-# CACAO Command-Line Interface
+# CACAO Command-Line Interface Login
 
 The CACAO Command-Line Interface (CLI) allows command-line users to interact with CACAO. The CLI is a Go program that can be installed on any system.
 
 ## Installation
 
-1. The CACAO CLI is a single binary that can be installed on any system. The most recent cli binaries can be downloaded from [the CACAO packages page on Gitlab](https://gitlab.com/cyverse/cacao/-/packages) or you can download from here:
+1. The CACAO CLI is a single binary that can be installed on Mac, Windows, and Linux. The most recent cli binaries can be downloaded from [the CACAO packages page on Gitlab](https://gitlab.com/cyverse/cacao/-/packages) or you can download using these direct links:
 
-- [CACAO Mac (Darwin) ARM64](https://gitlab.com/cyverse/cacao/-/package_files/101908036/download)
-- [CACAO Mac (Darwin) AMD64](https://gitlab.com/cyverse/cacao/-/package_files/101907995/download)
-- [CACAO Windows AMD64](https://gitlab.com/cyverse/cacao/-/package_files/101907940/download)
-- [CACAO Linux ARM64](https://gitlab.com/cyverse/cacao/-/package_files/101907892/download)
-- [CACAO Linux AMD64](https://gitlab.com/cyverse/cacao/-/package_files/101907877/download)
+- [CACAO Mac (Darwin) ARM64](https://gitlab.com/cyverse/cacao/-/package_files/109343739/download)
+- [CACAO Mac (Darwin) AMD64](https://gitlab.com/cyverse/cacao/-/package_files/109343715/download)
+- [CACAO Windows AMD64](https://gitlab.com/cyverse/cacao/-/package_files/109343698/download)
+- [CACAO Linux ARM64](https://gitlab.com/cyverse/cacao/-/package_files/109343675/download)
+- [CACAO Linux AMD64](https://gitlab.com/cyverse/cacao/-/package_files/109343660/download)
 
 2. If necessary, rename the file to `cacao.zip` and unzip the file. After unzipping, binary will be named `cacao_<os>_<architecture>` e.g. `cacao_darwin_arm64` or `cacao_linux_amd64`.
 
@@ -28,11 +28,47 @@ mv cacao_linux_amd64 /usr/local/bin/cacao
 
 ## Login with the CACAO CLI
 
-There are currently two approaches to logging in with the CACAO CLI.
+There are currently two approaches to logging in with the CACAO CLI. Most users should select Option 1 (Login with CACAO API Token). Option 2 (Login with ACCESS CI federated identity) is available for advanced users and is not generally recommended.
 
-### Login Option 1: Login with CIlogin federated identity
+### Login Option 1: Login with CACAO API Token (coming soon!)
 
-This method integrates with CILogin and requires a few steps.
+The CACAO API Token method is the easiest method to login with the CACAO CLI, where you can simply create a CACAO API Token using the CACAO user interface and use that token with the CLI.
+
+1. In the browser, login to CACAO at [https://cacao.jetstream-cloud.org](https://cacao.jetstream-cloud.org) with your ACCESS CI identity.
+
+2. Click on the Credentials menu
+
+3. Click on the "Add Credential" button
+
+4. Click on the "API Token" submenu
+
+5. In the Create API Token dialog window, enter the following:
+    * Token Name: provide a unique name for your token
+    * Description: optional, provide a description for your token
+    * Start Date: optional, leave as is to start the token immediately
+    * Expiration Date: optional, leave as is to expire the token in 1 year or you can select a different date
+
+6. Click on the "Create Token" button
+
+7. Your new token string should be displayed. Copy the token string to your clipboard (you will need this string in step 9)
+
+8. You can click the "Close" button to close the dialog window (or keep the dialog window open until it's no longer needed)
+
+9. In a terminal window, you can login with the following command: `cacao login --token <token>`
+
+***NOTE***
+
+`<token>` is the token string you copied WITHOUT the `<` and `>` characters.
+
+10. To test a successful login, you can execute a cacao command, such as: `cacao provider get`
+
+**NOTE: What to do if you encounter a login issue?**
+> Sometimes login using the command line will fail -- a typo happens, a copy-n-paste of a token happens, using the wrong api url happens, etc -- and you need to reset your login. To reset your login, you can use the following command:
+> `cacao logout`
+
+### Login Option 2: Login with ACCESS CI federated identity
+
+This method integrates with ACCESS CI and requires a few steps.
 
 1. `cacao login --browser`
 

--- a/docs/ui/cacao/cacao_cli_login.md
+++ b/docs/ui/cacao/cacao_cli_login.md
@@ -40,17 +40,24 @@ The CACAO API Token method is the easiest method to login with the CACAO CLI, wh
 
 3. Click on the "Add Credential" button
 
+![](images/api-token-add.png)
+
 4. Click on the "API Token" submenu
 
 5. In the Create API Token dialog window, enter the following:
+    * Token Type: leave value as "Personal"
     * Token Name: provide a unique name for your token
     * Description: optional, provide a description for your token
     * Start Date: optional, leave as is to start the token immediately
     * Expiration Date: optional, leave as is to expire the token in 1 year or you can select a different date
 
+![](images/api-token-wizard-create.png)
+
 6. Click on the "Create Token" button
 
-7. Your new token string should be displayed. Copy the token string to your clipboard (you will need this string in step 9)
+7. Your new token string should be displayed, but it will only be displayed once. Be sure to save it somewhere secure! Copy the token string to your clipboard (you will need this string in step 9)
+
+![](images/api-token-wizard-finish.png)
 
 8. You can click the "Close" button to close the dialog window (or keep the dialog window open until it's no longer needed)
 
@@ -128,78 +135,3 @@ $
 
 5. To test a successful login, you can execute a cacao command, such as: `cacao provider get`
 
-
-### Login Option 2: Login with CACAO API token using cacao cli
-
-1. While logged in with a Bearer token as above, use the cacao cli to create a cacao API token:
-
-```bash
-$ cacao token create -n token-name -t personal -e 2024-01-01T00:00:00Z -s api
-```
-Expiration (-e) is expected to be an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) datetime string. Use a reasonable expiration date, up to 1 year into the future.
-
-Optionally set a start date with -s.
-
-After entering the create command, the token you created will be displayed:
-
-```bash
-{
-    "id": "cptoken_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_clbqcdxxxxxxxxxxxxx",
-    "tid": "tid-clbqcdxxxxxxxxxxx",
-    "timestamp": "2023-11-17T17:43:19.319789233Z"
-}
-```
-
-**Be sure to save the token "id" in safe place! Treat it like a password!**  This is what you use to login and access the token. The access string is shown only once after creating the token.
-
-
-2. Log out of cacao via `cacao logout` and log back in via `cacao login --browser`
-3. Enter the CACAO API url: `https://cacao.jetstream-cloud.org/api`
-4. Next, enter the CACAO API token you created earlier:
-
-```bash
-Cacao API address (http://ca.cyverse.local/api): https://cacao.jetstream-cloud.org/api
-Please go to this URL in the browser: https://cacao.jetstream-cloud.org/api/user/login
-
-After login, you should get a JSON response, the auth token could be the value of following properties:
-- "IDToken" or "id_token" if keycloak
-- "access_token" if other auth provider
-
-Enter the auth token you get from browser: cptoken_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_clbqcdxxxxxxxxxxxxx
-```
-You are now logged in with a CACAO API token.
-
-
-### Login Option 2: Login with CACAO API token
-
-This method is significantly easier than the CILogin method, where you can simply create a CACAO API Token using the CACAO user interface and use that token with the CLI.
-
-1. Log in to [Jetstream2](https://cacao.jetstream-cloud.org/)
-2. Go to the [Credentials](https://cacao.jetstream-cloud.org/credentials) page
-3. Click "+ Add Credential" and choose "API Token":
-
-![](images/api-token-add.png)
-
-4. Choose a name for your token and optionally adjust the start and expiration dates or add a description:
-
-![](images/api-token-wizard-create.png)
-
-5. After pushing the 'Create Token' button, your token will appear on screen **only once**. Be sure to save it somewhere secure!
-
-![](images/api-token-wizard-finish.png)
-
-6. Log in to CACAO CLI via `cacao login --browser`, enter the CACAO API url: `https://cacao.jetstream-cloud.org/api`, and the token from step 5:
-
-```bash
-$ cacao login --browser
-Cacao API address (http://ca.cyverse.local/api): https://cacao.jetstream-cloud.org/api
-Please go to this URL in the browser: https://cacao.jetstream-cloud.org/api/user/login
-
-After login, you should get a JSON response, the auth token could be the value of following properties:
-- "IDToken" or "id_token" if keycloak
-- "access_token" if other auth provider
-
-Enter the auth token you get from browser: cptoken_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_clbqcdxxxxxxxxxxxxx
-```
-
-7. To test a successful login, you can execute a cacao command, such as: `cacao provider get`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,8 +160,9 @@ nav:
         - Deploying Magic Castle (virtual slurm cluster): ui/cacao/deployment_magic_castle.md
         - Deploying DADI (a community template): ui/cacao/deployment_dadi.md
       - Advanced Topics:
-        - Using the CACAO CLI: ui/cacao/advanced_cacao_cli.md
-        - Importing a Terraform Template: ui/cacao/import_terraform_template.md
+        - CACAO CLI Installing and Logging In: ui/cacao/cacao_cli_login.md
+        - CACAO CLI Importing a Terraform Template: ui/cacao/cacao_cli_import_terraform_template.md
+        - CACAO CLI Deploying Cloud Resources: ui/cacao/cacao_cli_deploy_resources.md
   - General VM Operations:
     - Security:
       - Firewalls: general/firewalls.md


### PR DESCRIPTION
This PR expands on cacao cli documentation by moving up the api token process for the cli and adding a page on how to deploy resources using the cli.