### PR TITLE
Fix cluster directory

### DIFF
--- a/docs/ui/exo/push-button-cluster.md
+++ b/docs/ui/exo/push-button-cluster.md
@@ -51,7 +51,7 @@ sudo su - rocky
 Go to the cluster repository directory: 
 
 ```bash
-cd ~/CRI_Jetstream_Cluster/
+cd ~/Jetstream_Cluster/
 ```
 
 Submit a test batch job: 


### PR DESCRIPTION
The repository name has changed from `CRI_Jetstream_Cluster` to `Jetstream_Cluster`